### PR TITLE
Gate PR preview deploy behind org membership check

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,41 +1,79 @@
 name: pr-preview
-on: pull_request_target
+on:
+  pull_request_target:
+  issue_comment:
+    types: [created]
+
 jobs:
-  build-upload:
+  check-permissions:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '/deploy-preview'))
+    outputs:
+      allowed: ${{ steps.check-team.outputs.allowed }}
+      pr-number: ${{ steps.check-team.outputs.number }}
+    steps:
+      - name: Get PR info and check permissions
+        id: check-team
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          COMMENT_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_ASSOCIATION: ${{ github.event.comment.author_association }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request_target" ]]; then
+            echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+            ASSOCIATION="$PR_ASSOCIATION"
+          else
+            echo "number=$COMMENT_NUMBER" >> $GITHUB_OUTPUT
+            ASSOCIATION="$COMMENT_ASSOCIATION"
+          fi
+
+          if [[ "$ASSOCIATION" == "OWNER" || "$ASSOCIATION" == "MEMBER" || "$ASSOCIATION" == "COLLABORATOR" ]]; then
+            echo "allowed=true" >> $GITHUB_OUTPUT
+            echo "User is a repo $ASSOCIATION — allowed"
+          else
+            echo "allowed=false" >> $GITHUB_OUTPUT
+            echo "User association is $ASSOCIATION — not allowed"
+          fi
+
+  deploy-preview:
+    runs-on: ubuntu-latest
+    needs: check-permissions
+    if: needs.check-permissions.outputs.allowed == 'true'
     env:
       SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
       SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
       GH_PR_TOKEN: ${{ secrets.GH_PR_TOKEN }}
-      GH_PR_NUM: ${{ github.event.number }}
+      GH_PR_NUM: ${{ needs.check-permissions.outputs.pr-number }}
     steps:
-      - uses: actions/checkout@v2
-      # Yes, we really want to checkout the PR
+      - uses: actions/checkout@v4
       - run: |
           git fetch origin pull/$GH_PR_NUM/head:tmp
           git checkout tmp
-      - run: |
-          git rev-parse origin/main
-          git rev-parse HEAD
-          git rev-parse origin/main..HEAD
-          git log origin/main..HEAD --format="%b"
-      # Yes, we really want to checkout the PR
-      # Injected by generate-workflows.js
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
       - run: corepack enable
+      - uses: actions/cache@v4
+        id: yarn-cache
+        name: Cache yarn deps
+        with:
+          path: |
+            node_modules
+            **/node_modules
+          key: ${{ runner.os }}-yarn-20-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
       - run: yarn install --immutable
-      - run: yarn lint:js
-        name: Lint JS
-        if: always()
-      - run: yarn lint:md
-        name: Lint MD
-        if: always()
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
       - run: yarn build
-        name: Build component groups
+        name: Build
       - run: yarn build:docs
         name: Build docs
-      - run: node .github/upload-preview.js packages/module/public
-        name: Upload docs
-        if: always()
+      - name: Upload docs
+        uses: patternfly/.github/.github/actions/surge-preview@main
+        with:
+          folder: packages/module/public


### PR DESCRIPTION
## Summary
- Adds a `check-permissions` job that verifies the PR author (or commenter) is an OWNER, MEMBER, or COLLABORATOR before running any steps that use secrets
- Adds `/deploy-preview` comment trigger so org members can request a preview on any PR
- Switches to the shared `patternfly/.github/.github/actions/surge-preview@main` action
- Updates `actions/checkout` from v2 to v4 and adds yarn dependency caching
- Removes lint steps from preview workflow (already covered by `check-pr.yml`)

Aligns with other repos in the extensions-testing org (e.g. react-console).

## Test plan
- [ ] Verify org member PRs still get automatic preview deploys
- [ ] Verify external contributor PRs skip the deploy-preview job
- [ ] Verify `/deploy-preview` comment from an org member triggers a preview
- [ ] Verify basic CI (check-pr.yml) still runs for all PRs regardless of author

🤖 Generated with [Claude Code](https://claude.com/claude-code)